### PR TITLE
Fixed compilation with Qt5

### DIFF
--- a/src/qobjecthelper.cpp
+++ b/src/qobjecthelper.cpp
@@ -6,7 +6,7 @@
   * This library is free software; you can redistribute it and/or
   * modify it under the terms of the GNU Lesser General Public
   * License version 2.1, as published by the Free Software Foundation.
-  * 
+  *
   *
   * This library is distributed in the hope that it will be useful,
   * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -66,7 +66,7 @@ void QObjectHelper::qvariant2qobject(const QVariantMap& variant, QObject* object
 
   QVariantMap::const_iterator iter;
   for (iter = variant.constBegin(); iter != variant.constEnd(); ++iter) {
-    int pIdx = metaobject->indexOfProperty( iter.key().toAscii() );
+    int pIdx = metaobject->indexOfProperty( iter.key().toLatin1() );
 
     if ( pIdx < 0 ) {
       continue;


### PR DESCRIPTION
There is no more toAscii in Qt5, toLatin1 means same
see https://bugreports.qt-project.org/browse/QTBUG-21872
