### PR TITLE
qobject2qvariant flags

### DIFF
--- a/src/qobjecthelper.cpp
+++ b/src/qobjecthelper.cpp
@@ -41,8 +41,8 @@ QObjectHelper::~QObjectHelper()
   delete d;
 }
 
-QVariantMap QObjectHelper::qobject2qvariant( const QObject* object,
-                              const QStringList& ignoredProperties)
+QVariantMap QObjectHelper::qobject2qvariant(const QObject* object, Flags flags,
+                                            const QStringList& ignoredProperties)
 {
   QVariantMap result;
   const QMetaObject *metaobject = object->metaObject();
@@ -55,10 +55,19 @@ QVariantMap QObjectHelper::qobject2qvariant( const QObject* object,
       continue;
 
     QVariant value = object->property(name);
+    if (value.isValid() && value.isNull() && !flags.testFlag(Flag_StoreNullVariants))
+        continue;
+    if (!value.isValid() && !flags.testFlag(Flag_StoreInvalidVariants))
+        continue;
     result[QLatin1String(name)] = value;
  }
   return result;
 }
+
+QVariantMap QObjectHelper::qobject2qvariant(const QObject *object, const QStringList &ignoredProperties)
+ {
+    return qobject2qvariant(object, Flag_All, ignoredProperties);
+ }
 
 void QObjectHelper::qvariant2qobject(const QVariantMap& variant, QObject* object)
 {

--- a/src/qobjecthelper.h
+++ b/src/qobjecthelper.h
@@ -121,13 +121,49 @@ namespace QJson {
       ~QObjectHelper();
 
     /**
+     * Flag controlling qobject2qvariant() behavior.
+     */
+    enum Flag {
+        /**
+         * No flag.
+         */
+        Flag_None,
+
+        /**
+         * Generate entries for NULL fields (QVariant::isNull() == true).
+         */
+        Flag_StoreNullVariants,
+
+        /**
+         * Generate entries for INVALID fields (QVariant::isValid() == false).
+         */
+        Flag_StoreInvalidVariants,
+
+        /**
+         * Generate entries for all fields.
+         */
+        Flag_All = Flag_StoreNullVariants | Flag_StoreInvalidVariants
+    };
+    Q_DECLARE_FLAGS(Flags, Flag)
+
+    /**
     * This method converts a QObject instance into a QVariantMap.
     *
     * @param object The QObject instance to be converted.
     * @param ignoredProperties Properties that won't be converted.
     */
-    static QVariantMap qobject2qvariant( const QObject* object,
-                                  const QStringList& ignoredProperties = QStringList(QString(QLatin1String("objectName"))));
+    static QVariantMap qobject2qvariant(const QObject* object,
+                                        const QStringList& ignoredProperties);
+
+    /**
+    * This method converts a QObject instance into a QVariantMap.
+    *
+    * @param object The QObject instance to be converted.
+    * @param flags Generation flags.
+    * @param ignoredProperties Properties that won't be converted.
+    */
+    static QVariantMap qobject2qvariant(const QObject* object, Flags flags = Flag_All,
+                                        const QStringList& ignoredProperties = QStringList(QString(QLatin1String("objectName"))));
 
     /**
     * This method converts a QVariantMap instance into a QObject

--- a/tests/qobjecthelper/testqobjecthelper.cpp
+++ b/tests/qobjecthelper/testqobjecthelper.cpp
@@ -38,6 +38,10 @@ class TestQObjectHelper: public QObject
   private slots:
     void testQObject2QVariant();
     void testQVariant2QObject();
+    void testQObject2QVariant_flagNone();
+    void testQObject2QVariant_flagStoreInvalid();
+    void testQObject2QVariant_flagStoreNull();
+    void testQObject2QVariant_flagAll();
 };
 
 using namespace QJson;
@@ -114,6 +118,116 @@ void TestQObjectHelper::testQVariant2QObject()
   QCOMPARE(person.dob(), dob);
   QCOMPARE(person.customField(), QVariant(nicknames));
   QCOMPARE(person.luckyNumber(), luckyNumber);
+}
+
+void TestQObjectHelper::testQObject2QVariant_flagNone()
+{
+  QString name;             //NULL variant
+  int phoneNumber = 123456;
+  Person::Gender gender = Person::Male;
+  QDate dob;                //NULL variant
+  QVariant nicknames;       //INVALID variant
+  quint16 luckyNumber = 123;
+
+  Person person;
+  person.setName(name);
+  person.setPhoneNumber(phoneNumber);
+  person.setGender(gender);
+  person.setDob(dob);
+  person.setCustomField(nicknames);
+  person.setLuckyNumber(luckyNumber);
+
+  QVariantMap expected;
+  expected[QLatin1String("phoneNumber")] = QVariant(phoneNumber);
+  expected[QLatin1String("gender")] = QVariant(gender);
+  expected[QLatin1String("luckyNumber")] = luckyNumber;
+
+  QVariantMap result = QObjectHelper::qobject2qvariant(&person, QObjectHelper::Flag_None);
+  QCOMPARE(result, expected);
+}
+
+void TestQObjectHelper::testQObject2QVariant_flagStoreInvalid()
+{
+  QString name;             //NULL variant
+  int phoneNumber = 123456;
+  Person::Gender gender = Person::Male;
+  QDate dob;                //NULL variant
+  QVariant nicknames;       //INVALID variant
+  quint16 luckyNumber = 123;
+
+  Person person;
+  person.setName(name);
+  person.setPhoneNumber(phoneNumber);
+  person.setGender(gender);
+  person.setDob(dob);
+  person.setCustomField(nicknames);
+  person.setLuckyNumber(luckyNumber);
+
+  QVariantMap expected;
+  expected[QLatin1String("phoneNumber")] = QVariant(phoneNumber);
+  expected[QLatin1String("gender")] = QVariant(gender);
+  expected[QLatin1String("customField")] = nicknames;
+  expected[QLatin1String("luckyNumber")] = luckyNumber;
+
+  QVariantMap result = QObjectHelper::qobject2qvariant(&person, QObjectHelper::Flag_StoreInvalidVariants);
+  QCOMPARE(result, expected);
+}
+
+void TestQObjectHelper::testQObject2QVariant_flagStoreNull()
+{
+  QString name;             //NULL variant
+  int phoneNumber = 123456;
+  Person::Gender gender = Person::Male;
+  QDate dob;                //NULL variant
+  QVariant nicknames;       //INVALID variant
+  quint16 luckyNumber = 123;
+
+  Person person;
+  person.setName(name);
+  person.setPhoneNumber(phoneNumber);
+  person.setGender(gender);
+  person.setDob(dob);
+  person.setCustomField(nicknames);
+  person.setLuckyNumber(luckyNumber);
+
+  QVariantMap expected;
+  expected[QLatin1String("name")] = QVariant(name);
+  expected[QLatin1String("phoneNumber")] = QVariant(phoneNumber);
+  expected[QLatin1String("gender")] = QVariant(gender);
+  expected[QLatin1String("dob")] = QVariant(dob);
+  expected[QLatin1String("luckyNumber")] = luckyNumber;
+
+  QVariantMap result = QObjectHelper::qobject2qvariant(&person, QObjectHelper::Flag_StoreNullVariants);
+  QCOMPARE(result, expected);
+}
+
+void TestQObjectHelper::testQObject2QVariant_flagAll()
+{
+  QString name;             //NULL variant
+  int phoneNumber = 123456;
+  Person::Gender gender = Person::Male;
+  QDate dob;                //NULL variant
+  QVariant nicknames;       //INVALID variant
+  quint16 luckyNumber = 123;
+
+  Person person;
+  person.setName(name);
+  person.setPhoneNumber(phoneNumber);
+  person.setGender(gender);
+  person.setDob(dob);
+  person.setCustomField(nicknames);
+  person.setLuckyNumber(luckyNumber);
+
+  QVariantMap expected;
+  expected[QLatin1String("name")] = QVariant(name);
+  expected[QLatin1String("phoneNumber")] = QVariant(phoneNumber);
+  expected[QLatin1String("gender")] = QVariant(gender);
+  expected[QLatin1String("dob")] = QVariant(dob);
+  expected[QLatin1String("customField")] = nicknames;
+  expected[QLatin1String("luckyNumber")] = luckyNumber;
+
+  QVariantMap result = QObjectHelper::qobject2qvariant(&person, QObjectHelper::Flag_All);
+  QCOMPARE(result, expected);
 }
 
 QTEST_MAIN(TestQObjectHelper)


### PR DESCRIPTION
Add flags in qobject2qvariant() allowing to decide if Null and Invalid
variants should be generated. This can be used to generate more compact
JSON structures.
