### PR TITLE
fixed locale independent double parsing.

### DIFF
--- a/src/json_scanner.cc
+++ b/src/json_scanner.cc
@@ -3394,7 +3394,12 @@ YY_RULE_SETUP
 #line 83 "json_scanner.yy"
 {
                 m_yylloc->columns(yyleng);
-                *m_yylval = QVariant(strtoull(yytext, NULL, 10));
+                // Get the old locale
+                char *old_locale = strdup (setlocale(LC_NUMERIC, NULL));
+                // Change locale to match JSON doubles
+                setlocale(LC_NUMERIC,"en_US");
+                *m_yylval = QVariant(strtod(yytext, NULL));
+                setlocale(LC_NUMERIC, old_locale);
                 if (errno == ERANGE) {
                     qCritical() << "Number is out of range: " << yytext;
                     return yy::json_parser::token::INVALID;
@@ -3422,7 +3427,13 @@ YY_RULE_SETUP
 #line 104 "json_scanner.yy"
 {
                 m_yylloc->columns(yyleng);
-                *m_yylval = QVariant(strtod_l(yytext, NULL, m_C_locale));
+                // Get the old locale
+                char *old_locale = strdup (setlocale(LC_NUMERIC, NULL));
+                // Change locale to match JSON doubles
+                setlocale(LC_NUMERIC,"en_US");
+                *m_yylval = QVariant(strtod(yytext, NULL));
+                setlocale(LC_NUMERIC, old_locale);
+
                 if (errno == ERANGE) {
                     qCritical() << "Number is out of range: " << yytext;
                     return yy::json_parser::token::INVALID;

--- a/src/json_scanner.cpp
+++ b/src/json_scanner.cpp
@@ -38,14 +38,10 @@ JSonScanner::JSonScanner(QIODevice* io)
   : m_allowSpecialNumbers(false),
     m_io (io),
     m_criticalError(false)
-{
-  m_C_locale = newlocale(LC_NUMERIC_MASK, "C", NULL);
-}
+{}
 
 JSonScanner::~JSonScanner()
-{
-  freelocale(m_C_locale);
-}
+{}
 
 void JSonScanner::allowSpecialNumbers(bool allow) {
   m_allowSpecialNumbers = allow;

--- a/src/json_scanner.h
+++ b/src/json_scanner.h
@@ -57,7 +57,6 @@ class JSonScanner : public yyFlexLexer
         yy::location* m_yylloc;
         bool m_criticalError;
         QString m_currentString;
-        locale_t m_C_locale;
 };
 
 #endif

--- a/src/json_scanner.yy
+++ b/src/json_scanner.yy
@@ -103,7 +103,12 @@ null          {
 
 -?(([0-9])|([1-9][0-9]+))(\.[0-9]+)?([Ee][+\-]?[0-9]+)? {
                 m_yylloc->columns(yyleng);
-                *m_yylval = QVariant(strtod_l(yytext, NULL, m_C_locale));
+				// Get the old locale
+				char *old_locale = strdup (setlocale(LC_NUMERIC, NULL));
+				// Change locale to match JSON doubles
+				setlocale(LC_NUMERIC,"en_US");
+                *m_yylval = QVariant(strtod_l(yytext, NULL));
+				setlocale(LC_NUMERIC, old_locale);
                 if (errno == ERANGE) {
                     qCritical() << "Number is out of range: " << yytext;
                     return yy::json_parser::token::INVALID;


### PR DESCRIPTION
Fixed issue #28 "Double parsing broken ?" by changing the app locale and restoring the old one after the string  to double conversion.
