### PR TITLE
Fix build for Visual Studio 2008/2010

### DIFF
--- a/src/json_scanner.cpp
+++ b/src/json_scanner.cpp
@@ -37,12 +37,20 @@ JSonScanner::JSonScanner(QIODevice* io)
     m_io (io),
     m_criticalError(false)
 {
+#ifdef Q_OS_WIN
+  m_C_locale = _create_locale(LC_NUMERIC, "C");
+#else
   m_C_locale = newlocale(LC_NUMERIC_MASK, "C", NULL);
+#endif
 }
 
 JSonScanner::~JSonScanner()
 {
-  freelocale(m_C_locale);
+#ifdef Q_OS_WIN
+  _free_locale(m_C_locale);
+#else
+  free_locale(m_C_locale);
+#endif
 }
 
 void JSonScanner::allowSpecialNumbers(bool allow) {

--- a/src/json_scanner.h
+++ b/src/json_scanner.h
@@ -34,7 +34,12 @@
 #include "parser_p.h"
 
 #include <locale.h>
+
+#ifdef Q_OS_WIN
+#include <xlocale>
+#else
 #include <xlocale.h>
+#endif
 
 namespace yy {
   class location;
@@ -60,7 +65,11 @@ class JSonScanner : public yyFlexLexer
         yy::location* m_yylloc;
         bool m_criticalError;
         QString m_currentString;
+#ifdef Q_OS_WIN
+        _locale_t m_C_locale;
+#else
         locale_t m_C_locale;
+#endif
 };
 
 #endif


### PR DESCRIPTION
VS2008/2010 does not have the `xlocale.h` header but instead its `xlocale`. Also creating and freeing the locale object have different function names and `_locale_t` is `locale_t`.

Did not test Visual Studio 2012. If it builds there without these changes VC compiler version needs to be added to the `#ifdef`s.

It seems that you support mainly the mingw environment for Windows. I suppose the code builds fine there? Let me know if that is the case and I'll figure out checks that we are actually using the Visual Studio compiler.
