### PR TITLE
Switch from native locale handling to QLocale

### DIFF
--- a/src/json_scanner.cpp
+++ b/src/json_scanner.cpp
@@ -35,18 +35,14 @@
 JSonScanner::JSonScanner(QIODevice* io)
   : m_allowSpecialNumbers(false),
     m_io (io),
-    m_criticalError(false)
+    m_criticalError(false),
+    m_C_locale(QLocale::C)
 {
-#ifdef Q_OS_WIN
-  m_C_locale = _create_locale(LC_NUMERIC, "C");
-#else
-  m_C_locale = newlocale(LC_NUMERIC_MASK, "C", NULL);
-#endif
+
 }
 
 JSonScanner::~JSonScanner()
 {
-  freelocale(m_C_locale);
 }
 
 void JSonScanner::allowSpecialNumbers(bool allow) {

--- a/src/json_scanner.h
+++ b/src/json_scanner.h
@@ -23,6 +23,7 @@
 
 #include <QtCore/QIODevice>
 #include <QtCore/QVariant>
+#include <QtCore/QLocale>
 
 #define YYSTYPE QVariant
 
@@ -33,15 +34,7 @@
 
 #include "parser_p.h"
 
-#include <locale.h>
 
-#ifdef Q_OS_WIN
-#include <xlocale>
-#define locale_t _locale_t
-#define freelocale _free_locale
-#else
-#include <xlocale.h>
-#endif
 
 namespace yy {
   class location;
@@ -67,7 +60,7 @@ class JSonScanner : public yyFlexLexer
         yy::location* m_yylloc;
         bool m_criticalError;
         QString m_currentString;
-        locale_t m_C_locale;
+        QLocale m_C_locale;
 };
 
 #endif

--- a/src/json_scanner.yy
+++ b/src/json_scanner.yy
@@ -29,12 +29,6 @@
   #include "json_scanner.h"
   #include "json_parser.hh"
 
-  #if defined(_WIN32) && !defined(__MINGW32__)
-  #define strtoll _strtoi64
-  #define strtoull _strtoui64
-  #define strtod_l _strtod_l
-  #endif
-
   #define YY_USER_INIT if(m_allowSpecialNumbers) { \
     BEGIN(ALLOW_SPECIAL_NUMBERS); \
   }
@@ -103,8 +97,9 @@ null          {
 
 -?(([0-9])|([1-9][0-9]+))(\.[0-9]+)?([Ee][+\-]?[0-9]+)? {
                 m_yylloc->columns(yyleng);
-                *m_yylval = QVariant(strtod_l(yytext, NULL, m_C_locale));
-                if (errno == ERANGE) {
+                bool ok;
+                *m_yylval = QVariant(m_C_locale.toDouble(QLatin1String(yytext),&ok));
+                if (!ok) {
                     qCritical() << "Number is out of range: " << yytext;
                     return yy::json_parser::token::INVALID;
                 }

--- a/tests/parser/testparser.cpp
+++ b/tests/parser/testparser.cpp
@@ -27,8 +27,7 @@
 #include <QJson/Parser>
 #include <QJson/Serializer>
 
-#include <locale.h>
-#include <xlocale.h>
+#include <QLocale>
 
 class TestParser: public QObject
 {
@@ -380,13 +379,13 @@ void TestParser::testTopLevelValues_data() {
 }
 
 void TestParser::testDoubleParsingWithDifferentLocale() {
-  locale_t oldLocale = duplocale(LC_GLOBAL_LOCALE);
-  locale_t itLocale  = newlocale(LC_NUMERIC_MASK, "it_IT.utf8", NULL);
+  QLocale oldLocale;
+  QLocale itLocale(QLatin1String("it_IT.utf8"));
 
-  QVERIFY(itLocale != NULL);
+  QCOMPARE(itLocale.name(), QLatin1String("it_IT") );
 
   // the Italian locale uses ',' as digit separator.
-  uselocale(itLocale);
+  QLocale::setDefault(itLocale);
 
   Parser parser;
   bool ok;
@@ -395,9 +394,7 @@ void TestParser::testDoubleParsingWithDifferentLocale() {
 
   QCOMPARE(result.toDouble(), 12.3);
 
-  uselocale(oldLocale);
-
-  freelocale(itLocale);
+  QLocale::setDefault(oldLocale);
 }
 
 void TestParser::testReadWrite()

--- a/tests/scanner/testscanner.cpp
+++ b/tests/scanner/testscanner.cpp
@@ -165,7 +165,7 @@ void TestScanner::scanTokens_data() {
 
   QTest::newRow("too large unsinged number") << QByteArray("18446744073709551616") << false << false << TOKEN(INVALID) << QVariant(ULLONG_MAX) << 1 << 0 << 1 << 20;
   QTest::newRow("too large signed number") << QByteArray("-9223372036854775808") << false << false << TOKEN(INVALID) << QVariant(LLONG_MIN) << 1 << 0 << 1 << 20;
-  QTest::newRow("too large exponential") << QByteArray("1.7976931348623157e309") << false << false << TOKEN(INVALID) << QVariant(HUGE_VAL) << 1 << 0 << 1 << 22;
+  QTest::newRow("too large exponential") << QByteArray("1.7976931348623157e309") << false << false << TOKEN(INVALID) << QVariant(0) << 1 << 0 << 1 << 22;
   QTest::newRow("not allowed nan") << QByteArray("nan") << false << false << TOKEN(INVALID) << QVariant() << 1 << 0 << 1 << 1;
   QTest::newRow("not allowed infinity") << QByteArray("Infinity") << false << false << TOKEN(INVALID) << QVariant() << 1 << 0 << 1 << 1;
   QTest::newRow("unknown") << QByteArray("*") << true << false << TOKEN(INVALID) << QVariant()  << 1 << 0 << 1 << 1;


### PR DESCRIPTION
This ensures building on platforms where Qt is supported, rather than
just work on linux/gcc and msvc. Notably, mingw also works now.

This fixes issue 32 and 33.

Performance wise, QLocale is slightly slower, but for a 10mb json file
with a good mix of objects, arrays, doubles, integers and strings, the
timings was around 975 msec for using 'native locales' and 980 msec for
using QLocale. It was reproducibly approximately 5 msec slower for a
10mb file.

Note that the json_scanner.cc needs to be regenerated. I don't have the
same flex version, so the diff in that file was quite large.
