### PR TITLE
Fixed bug with incomplete QBuffer opening procedure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 lib
 Makefile
 doc/html
+build
+*.user
 
 # -- kdevelop
 .kdev4

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -116,7 +116,7 @@ QVariant Parser::parse (QIODevice* io, bool* ok)
 
 QVariant Parser::parse(const QByteArray& jsonString, bool* ok) {
   QBuffer buffer;
-  buffer.open(QBuffer::ReadWrite);
+  buffer.open(QBuffer::ReadWrite | QBuffer::Text);
   buffer.write(jsonString);
   buffer.seek(0);
   return parse (&buffer, ok);


### PR DESCRIPTION
When trying to run sample code on Qt 5.3 got a bunch of errors:

```
QBuffer::open: Buffer access not specified
QIODevice::write: device not open
QIODevice::seek: The device is not open
QBuffer::open: Buffer access not specified
```

Figured out why this happens and fixed this with simply specifying QJson to open QBuffer as a text.

And yeah, added some files and directories appearing during the sample compilation to gitignore.
