### PR TITLE
cmake: added static library support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,9 @@ IF (WIN32)
   SET(CMAKE_DEBUG_POSTFIX "d")
 ENDIF (WIN32)
 
+# BUILD_SHARED_LIBS is cmake variable. Need to change default value.
+option(BUILD_SHARED_LIBS "Build shared library" ON)
+
 OPTION(OSX_FRAMEWORK "Build a Mac OS X Framework")
 SET(FRAMEWORK_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/Library/Frameworks"
     CACHE PATH "Where to place qjson.framework if OSX_FRAMEWORK is selected")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,7 +23,7 @@ set (qjson_HEADERS parser.h parserrunnable.h qobjecthelper.h serializer.h serial
 # Required to use the intree copy of FlexLexer.h
 INCLUDE_DIRECTORIES(.)
 
-add_library (qjson SHARED ${qjson_SRCS} ${qjson_MOC_SRCS} ${qjson_HEADERS})
+add_library (qjson ${qjson_SRCS} ${qjson_MOC_SRCS} ${qjson_HEADERS})
 IF (Qt5Core_FOUND)
   target_link_libraries( qjson ${Qt5Core_LIBRARIES})
 ELSE()


### PR DESCRIPTION
CMake provides BUILD_SHARED_LIBS option to choose library type in add_library
when it is not set explicity. Need to use this option
