### PR TITLE
Support older cmake versions (2.8.9)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,9 @@ CMAKE_MINIMUM_REQUIRED(VERSION 2.8.8)
 CMAKE_POLICY(SET CMP0003 NEW)
 
 # Do not link against qtmain on Windows
-cmake_policy(SET CMP0020 OLD)
+if(POLICY CMP0020)
+	cmake_policy(SET CMP0020 OLD)
+endif()
 
 set(CMAKE_INSTALL_NAME_DIR ${LIB_INSTALL_DIR})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,7 +45,7 @@ if(NOT ANDROID)
 endif()
 
 if(NOT BUILD_SHARED_LIBS)
-  target_compile_definitions(qjson PUBLIC QJSON_STATIC)
+	set_target_properties( qjson PROPERTIES COMPILE_DEFINITIONS "QJSON_STATIC")
 endif()
 
 set_target_properties(qjson PROPERTIES


### PR DESCRIPTION
Added support for cmake 2.8.9. Policy should be checked before set, definition for target may be set with old method (fundion target_compile_definitions is not supported in cmake 2.8.9).
For result - project is now can be compiled on current stable Debian (wheezy).