### PR TITLE
Add io device closing management in parser

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -70,7 +70,22 @@ Parser::~Parser()
   delete d;
 }
 
+
 QVariant Parser::parse (QIODevice* io, bool* ok)
+{
+  if (!io->isOpen()) {
+    if (!io->open(QIODevice::ReadOnly)) {
+      if (ok != 0)
+        *ok = false;
+      qCritical ("Error opening device");
+      return QVariant();
+    }
+  }
+  return parse(io, true, ok);
+}
+
+
+QVariant Parser::parse (QIODevice* io,bool alwaysCloseDevice, bool* ok)
 {
   d->reset();
 
@@ -81,13 +96,16 @@ QVariant Parser::parse (QIODevice* io, bool* ok)
       qCritical ("Error opening device");
       return QVariant();
     }
+    alwaysCloseDevice = true;
   }
 
   if (!io->isReadable()) {
     if (ok != 0)
       *ok = false;
     qCritical ("Device is not readable");
-    io->close();
+    if(alwaysCloseDevice) {
+      io->close();
+    }
     return QVariant();
   }
 
@@ -110,7 +128,10 @@ QVariant Parser::parse (QIODevice* io, bool* ok)
   if (ok != 0)
     *ok = !d->m_error;
 
-  io->close();
+  if(alwaysCloseDevice) {
+    io->close();
+  }
+
   return d->m_result;
 }
 

--- a/src/parser.h
+++ b/src/parser.h
@@ -53,6 +53,15 @@ namespace QJson {
       QVariant parse(QIODevice* io, bool* ok = 0);
 
       /**
+      * Read JSON string from the I/O Device and converts it to a QVariant object
+      * @param io Input output device
+      * @param alwaysCloseDevice if false, io is kept in the same open state, otherwise io is left closed 
+      * @param ok if a conversion error occurs, *ok is set to false; otherwise *ok is set to true.
+      * @returns a QVariant object generated from the JSON string
+      */
+      QVariant parse(QIODevice* io,bool alwaysCloseDevice, bool* ok = 0);
+
+      /**
       * This is a method provided for convenience.
       * @param jsonData data containing the JSON object representation
       * @param ok if a conversion error occurs, *ok is set to false; otherwise *ok is set to true.


### PR DESCRIPTION
Hi,

Today QJson library always closes the QIODevice at the end of parsing.
This may cause problems with volatile data that are destroyed when the I/O device is closed (i.e. network connection, temporary file, memory buffer).

To prevent this, I added a prototype to the parser with a boolean to force the device to be closed after parsing.
This does not break the old behavior and allows the client to choose if the file must be closed or not.

Is it possible to merge this change in the mainline ?
Thanks,
Xavier.
