### PR TITLE
Fix cross compile build for Blackberry, add std:: namespace

### DIFF
--- a/src/FlexLexer.h
+++ b/src/FlexLexer.h
@@ -173,8 +173,8 @@ protected:
 	int yy_did_buffer_switch_on_eof;
 
 
-	size_t yy_buffer_stack_top; /**< index of top of stack. */
-	size_t yy_buffer_stack_max; /**< capacity of stack. */
+    std::size_t yy_buffer_stack_top; /**< index of top of stack. */
+    std::size_t yy_buffer_stack_max; /**< capacity of stack. */
 	struct yy_buffer_state ** yy_buffer_stack; /**< Stack as an array. */
 	void yyensure_buffer_stack(void);
 

--- a/src/json_scanner.cc
+++ b/src/json_scanner.cc
@@ -168,7 +168,7 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
 
 #ifndef YY_TYPEDEF_YY_SIZE_T
 #define YY_TYPEDEF_YY_SIZE_T
-typedef size_t yy_size_t;
+typedef std::size_t yy_size_t;
 #endif
 
 extern yy_size_t yyleng;


### PR DESCRIPTION
I didn't have bison/flex knowledge, how can I add std:: namespace for bison/flex in json_parser.yy
