### PR TITLE
support QJSON_SUFFIX, to be parallel-installable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ IF (Qt5Core_FOUND)
   INCLUDE_DIRECTORIES(${Qt5Core_INCLUDE_DIRS})
   ADD_DEFINITIONS(${Qt5Core_DEFINITIONS})
   SET(PC_Requires "Qt5Core")
+  set(QJSON_SUFFIX "-qt5")
   # Tell CMake to run moc when necessary:
   set(CMAKE_AUTOMOC ON)
   # As moc files are generated in the binary dir, tell CMake
@@ -75,7 +76,7 @@ ENDIF()
 SET (LIB_SUFFIX "" CACHE STRING "Define suffix of directory name (32/64)" )
 SET (LIB_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}" CACHE STRING "Directory where lib will install")
 SET (INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/include" CACHE PATH "The directory the headers are installed in")
-SET (CMAKECONFIG_INSTALL_DIR "${LIB_INSTALL_DIR}/cmake/${CMAKE_PROJECT_NAME}" CACHE PATH "Directory where to install QJSONConfig.cmake")
+SET (CMAKECONFIG_INSTALL_DIR "${LIB_INSTALL_DIR}/cmake/${CMAKE_PROJECT_NAME}${QJSON_SUFFIX}" CACHE PATH "Directory where to install QJSONConfig.cmake")
 
 set(QJSON_LIB_MAJOR_VERSION "0")
 set(QJSON_LIB_MINOR_VERSION "8")
@@ -88,9 +89,9 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib" )
 # pkg-config
 IF (NOT WIN32)
   CONFIGURE_FILE (${CMAKE_CURRENT_SOURCE_DIR}/QJson.pc.in
-                  ${CMAKE_CURRENT_BINARY_DIR}/QJson.pc
+                  ${CMAKE_CURRENT_BINARY_DIR}/QJson${QJSON_SUFFIX}.pc
                   @ONLY)
-  INSTALL (FILES ${CMAKE_CURRENT_BINARY_DIR}/QJson.pc
+  INSTALL (FILES ${CMAKE_CURRENT_BINARY_DIR}/QJson${QJSON_SUFFIX}.pc
            DESTINATION ${LIB_INSTALL_DIR}/pkgconfig)
 ENDIF (NOT WIN32)
 
@@ -106,7 +107,7 @@ CONFIGURE_FILE(
   "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
   IMMEDIATE @ONLY)
 
-INSTALL(EXPORT qjson-export DESTINATION ${CMAKECONFIG_INSTALL_DIR} FILE QJSONTargets.cmake)
+INSTALL(EXPORT qjson-export DESTINATION ${CMAKECONFIG_INSTALL_DIR} FILE QJSON${QJSON_SUFFIX}Targets.cmake)
 
 # figure out the relative path from the installed Config.cmake file to the install prefix (which may be at
 # runtime different from the chosen CMAKE_INSTALL_PREFIX if under Windows the package was installed anywhere)
@@ -115,13 +116,13 @@ file(RELATIVE_PATH relInstallDir ${CMAKE_INSTALL_PREFIX}/${CMAKECONFIG_INSTALL_D
 
 # cmake-modules
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/QJSONConfig.cmake.in
-               ${CMAKE_CURRENT_BINARY_DIR}/QJSONConfig.cmake
+               ${CMAKE_CURRENT_BINARY_DIR}/QJSON${QJSON_SUFFIX}Config.cmake
                @ONLY)
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/QJSONConfigVersion.cmake.in
-               ${CMAKE_CURRENT_BINARY_DIR}/QJSONConfigVersion.cmake
+               ${CMAKE_CURRENT_BINARY_DIR}/QJSON${QJSON_SUFFIX}ConfigVersion.cmake
                @ONLY)
-INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/QJSONConfig.cmake
-              ${CMAKE_CURRENT_BINARY_DIR}/QJSONConfigVersion.cmake
+INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/QJSON${QJSON_SUFFIX}Config.cmake
+              ${CMAKE_CURRENT_BINARY_DIR}/QJSON${QJSON_SUFFIX}ConfigVersion.cmake
         DESTINATION "${CMAKECONFIG_INSTALL_DIR}")
 
 ADD_CUSTOM_TARGET(uninstall

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,36 +30,36 @@ if(WIN32 AND QJSON_BUILD_TESTS AND BUILD_SHARED_LIBS)
   add_library(qjson_scanner STATIC json_scanner.cpp)
 endif()
 
-add_library (qjson ${qjson_SRCS} ${qjson_MOC_SRCS} ${qjson_HEADERS})
+add_library (qjson${QJSON_SUFFIX} ${qjson_SRCS} ${qjson_MOC_SRCS} ${qjson_HEADERS})
 IF (Qt5Core_FOUND)
-  target_link_libraries( qjson ${Qt5Core_LIBRARIES})
+  target_link_libraries( qjson${QJSON_SUFFIX} ${Qt5Core_LIBRARIES})
 ELSE()
-  target_link_libraries( qjson ${QT_LIBRARIES})
+  target_link_libraries( qjson${QJSON_SUFFIX} ${QT_LIBRARIES})
 ENDIF()
 
 if(NOT ANDROID)
-	set_target_properties(qjson PROPERTIES
+	set_target_properties(qjson${QJSON_SUFFIX} PROPERTIES
 	                      VERSION ${QJSON_LIB_MAJOR_VERSION}.${QJSON_LIB_MINOR_VERSION}.${QJSON_LIB_PATCH_VERSION}
                               SOVERSION ${QJSON_LIB_MAJOR_VERSION}
 	                      )
 endif()
 
 if(NOT BUILD_SHARED_LIBS)
-	set_target_properties( qjson PROPERTIES COMPILE_DEFINITIONS "QJSON_STATIC")
+	set_target_properties( qjson${QJSON_SUFFIX} PROPERTIES COMPILE_DEFINITIONS "QJSON_STATIC")
 endif()
 
-set_target_properties(qjson PROPERTIES
+set_target_properties(qjson${QJSON_SUFFIX} PROPERTIES
                       DEFINE_SYMBOL QJSON_MAKEDLL
                       PUBLIC_HEADER "${qjson_HEADERS}"
                       FRAMEWORK ${OSX_FRAMEWORK}
                       )
 
-INSTALL(TARGETS qjson EXPORT qjson-export
+INSTALL(TARGETS qjson${QJSON_SUFFIX} EXPORT qjson-export
    LIBRARY DESTINATION ${LIB_INSTALL_DIR}
    RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
    ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
    FRAMEWORK DESTINATION ${FRAMEWORK_INSTALL_DIR}
-   PUBLIC_HEADER DESTINATION ${INCLUDE_INSTALL_DIR}/qjson
+   PUBLIC_HEADER DESTINATION ${INCLUDE_INSTALL_DIR}/qjson${QJSON_SUFFIX}
 )
 
 if(MSVC)

--- a/tests/benchmarks/CMakeLists.txt
+++ b/tests/benchmarks/CMakeLists.txt
@@ -27,7 +27,7 @@ FOREACH(test ${UNIT_TESTS})
     ${test}
     ${QT_LIBRARIES}
     ${TEST_LIBRARIES}
-    qjson
+    qjson${QJSON_SUFFIX}
   )
   if (QJSON_TEST_OUTPUT STREQUAL "xml")
     # produce XML output

--- a/tests/cmdline_tester/CMakeLists.txt
+++ b/tests/cmdline_tester/CMakeLists.txt
@@ -31,5 +31,5 @@ TARGET_LINK_LIBRARIES(
   cmdline_tester
   ${QT_LIBRARIES}
   ${Qt5Widgets_LIBRARIES}
-  qjson
+  qjson${QJSON_SUFFIX}
 )

--- a/tests/parser/CMakeLists.txt
+++ b/tests/parser/CMakeLists.txt
@@ -35,7 +35,7 @@ FOREACH(test ${UNIT_TESTS})
     ${test}
     ${QT_LIBRARIES}
     ${TEST_LIBRARIES}
-    qjson
+    qjson${QJSON_SUFFIX}
   )
   if (QJSON_TEST_OUTPUT STREQUAL "xml")
     # produce XML output

--- a/tests/qobjecthelper/CMakeLists.txt
+++ b/tests/qobjecthelper/CMakeLists.txt
@@ -43,7 +43,7 @@ FOREACH(test ${UNIT_TESTS})
     ${test}
     ${QT_LIBRARIES}
     ${TEST_LIBRARIES}
-    qjson
+    qjson${QJSON_SUFFIX}
     qjson_test_support
   )
   if (QJSON_TEST_OUTPUT STREQUAL "xml")

--- a/tests/scanner/CMakeLists.txt
+++ b/tests/scanner/CMakeLists.txt
@@ -40,7 +40,7 @@ FOREACH(test ${UNIT_TESTS})
     ${test}
     ${QT_LIBRARIES}
     ${TEST_LIBRARIES}
-    qjson
+    qjson${QJSON_SUFFIX}
     ${QJSON_SCANNER}
   )
   if (QJSON_TEST_OUTPUT STREQUAL "xml")

--- a/tests/serializer/CMakeLists.txt
+++ b/tests/serializer/CMakeLists.txt
@@ -35,7 +35,7 @@ FOREACH(test ${UNIT_TESTS})
     ${test}
     ${QT_LIBRARIES}
     ${TEST_LIBRARIES}
-    qjson
+    qjson${QJSON_SUFFIX}
   )
   if (QJSON_TEST_OUTPUT STREQUAL "xml")
     # produce XML output


### PR DESCRIPTION
Support full parallel-installability of Qt4/Qt5 builds. Besides,
Qt5 builds are binary incompatible anyway, so should not be using
the same library soname.